### PR TITLE
Reference to 'vassal' should be 'vassals'

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,7 @@ uwsgi:
       emperor: '/etc/uwsgi-emperor/vassals'
 
   # vassal configuration for uwsgi emperor
-  vassal:
+  vassals:
     managed:
       test_app.ini:
         enabled: True


### PR DESCRIPTION
As per `vassal_config.sls` it loops over `uwsgi.vassals` not `uwsgi.vassal` as referenced in `pillar.example` file.
