### PR TITLE
Added support for Fedora/RHEL

### DIFF
--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -38,6 +38,22 @@
       'emperor_config'          : 'emperor.ini',
       'plugins'                 : ['uwsgi-plugin-python','uwsgi-plugin-python2'],
     },
+    'RedHat': {
+      'server_pkg'              : 'uwsgi',
+      'uwsgi_service'           : 'uwsgi',
+      'application_available'   : '/etc/uwsgi',
+      'application_enabled'     : '/etc/uwsgi',
+      'application_use_symlink' : False,
+      'emperor_pkg'             : 'uwsgi',
+      'emperor_service'         : 'uwsgi',
+      'emperor_dir'             : '/etc',
+      'vassal_available'        : '/etc/uwsgi.d',
+      'vassal_enabled'          : '/etc/uwsgi.d',
+      'vassal_use_symlink'      : False,
+      'emperor_config'          : 'uwsgi.ini',
+      'plugins'                 : ['uwsgi-plugin-python','uwsgi-plugin-python27'],
+    },
+
   }, default='Debian' ),
 
   'package': {


### PR DESCRIPTION
uwsgi package is in EPEL6 and EPEL7 for CentOS along with packages in Fedora since 21.

`emperor_dir` is set to `/etc` cause `uwsgi` package contains:

```
/etc/uwsgi.ini
/etc/uwsgi.d/
```

and `/etc/uwsgi.d/` is for vassals (default `/etc/uwsgi.ini` has `emperor = /etc/uwsgi.d` in it).
