### PR TITLE
Fixed default plugins for RedHat

### DIFF
--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -51,7 +51,7 @@
       'vassal_enabled'          : '/etc/uwsgi.d',
       'vassal_use_symlink'      : False,
       'emperor_config'          : 'uwsgi.ini',
-      'plugins'                 : ['uwsgi-plugin-python','uwsgi-plugin-python27'],
+      'plugins'                 : ['uwsgi-plugin-python'],
     },
 
   }, default='Debian' ),


### PR DESCRIPTION
There is no python27 for EL6 in standard repo nor EPEL
