### PR TITLE
Configure RedHat defaults properly

### DIFF
--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -76,10 +76,10 @@
     'managed': {},
   },
 
-  'emperor': salt['grains.filter_by']({
-    'Debian': {
-      'opts': {},
-      'config': {
+  'emperor': {
+    'opts': {},
+    'config': salt['grains.filter_by']({
+      'Debian': {
         'autoload': 'true',
         'master': 'true',
         'workers': '2',
@@ -89,10 +89,7 @@
         'gid': 'www-data',
         'emperor': '/etc/uwsgi-emperor/vassals',
       },
-    },
-    'RedHat': {
-      'opts': {},
-      'config': {
+      'RedHat': {
         'autoload': 'true',
         'master': 'true',
         'workers': '2',

--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -117,6 +117,8 @@
 
 {%- if salt['grains.get']('os_family') == 'RedHat' %}
   {%- if salt['grains.get']('osmajorrelease')|int < 7 %}
-    {%- do uwsgi['emperor']['config'].update({'daemonize': '/var/log/uwsgi.log'}) %}
+    {%- if 'daemonize' not in uwsgi['emperor']['config'] %}
+      {%- do uwsgi['emperor']['config'].update({'daemonize': '/var/log/uwsgi.log'}) %}
+    {%- endif %}
   {%- endif %}
 {%- endif %}

--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -99,8 +99,8 @@
         'gid': 'uwsgi',
         'emperor': '/etc/uwsgi.d',
       },
-    },
-  }, default='Debian'),
+    }, default='Debian'),
+  },
 
   'vassals': {
     'disabled_postfix': '.disabled',

--- a/uwsgi/map.jinja
+++ b/uwsgi/map.jinja
@@ -76,19 +76,34 @@
     'managed': {},
   },
 
-  'emperor': {
-    'opts': {},
-    'config': {
-      'autoload': 'true',
-      'master': 'true',
-      'workers': '2',
-      'no-orphans': 'true',
-      'log-date': 'true',
-      'uid': 'www-data',
-      'gid': 'www-data',
-      'emperor': '/etc/uwsgi-emperor/vassals',
+  'emperor': salt['grains.filter_by']({
+    'Debian': {
+      'opts': {},
+      'config': {
+        'autoload': 'true',
+        'master': 'true',
+        'workers': '2',
+        'no-orphans': 'true',
+        'log-date': 'true',
+        'uid': 'www-data',
+        'gid': 'www-data',
+        'emperor': '/etc/uwsgi-emperor/vassals',
+      },
     },
-  },
+    'RedHat': {
+      'opts': {},
+      'config': {
+        'autoload': 'true',
+        'master': 'true',
+        'workers': '2',
+        'no-orphans': 'true',
+        'log-date': 'true',
+        'uid': 'uwsgi',
+        'gid': 'uwsgi',
+        'emperor': '/etc/uwsgi.d',
+      },
+    },
+  }, default='Debian'),
 
   'vassals': {
     'disabled_postfix': '.disabled',
@@ -103,5 +118,8 @@
 
 }, merge=True) %}
 
-
-
+{%- if salt['grains.get']('os_family') == 'RedHat' %}
+  {%- if salt['grains.get']('osmajorrelease')|int < 7 %}
+    {%- do uwsgi['emperor']['config'].update({'daemonize': '/var/log/uwsgi.log'}) %}
+  {%- endif %}
+{%- endif %}


### PR DESCRIPTION
Things to know:
— can not properly work with older Fedora, but who uses Fedora older than 15? Officially supported are latest, and one-before-latest (right now these are 22 and 21)
— uwsgi from EPEL7 uses systemd with `sd_notify()` so we don't need to daemonize it
— uwsgi from EPEL6 (and olders?) uses traditional initscript, so we need to daemonize uwsgi on those systems

I already filled bug about missing `daemonize` on EPEL6 ([BZ#1261942](https://bugzilla.redhat.com/show_bug.cgi?id=1261942))
