### PR TITLE
fixes small mistake in example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -9,7 +9,7 @@ uwsgi:
     opts: {} # this partially exposes parameters of all pkg.installed used
 
   # application in the uwsgi server default it will be places in app_available
-  application:
+  applications:
     managed:
       my_test_app.ini: # relative pathname of the application file
         # may be True, False, or None where True is enabled, False, disabled, and None indicates no action


### PR DESCRIPTION
pillar should contain the dictionary 'applications' not 'application'
