### PR TITLE
Add support for config blocks as lists

### DIFF
--- a/uwsgi/emperor/files/emperor.jinja
+++ b/uwsgi/emperor/files/emperor.jinja
@@ -26,6 +26,4 @@
 #
 # This file is managed by Salt.
 [uwsgi]
-{% for key, value in config.items() %}
-{{ emperor_block(value, key) }}
-{%- endfor -%}
+{{ emperor_block(config) }}

--- a/uwsgi/emperor/files/emperor.jinja
+++ b/uwsgi/emperor/files/emperor.jinja
@@ -1,19 +1,19 @@
 {% set indent_increment = 4 %}
 
-{%- macro emperor_block(value, key=None, operator=' = ', delim='', ind=0) -%}
+{%- macro emperor_block(value, key=None, operator=' = ', lb='\n', delim='', ind=0) -%}
     {%- if value != None -%}
     {%- if value is number or value is string -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- elif value is mapping -%}
-        {%- for k, v in value.items() %}
-{{ emperor_block(v, k, operator, delim, ind) }}
+        {%- for k, v in value.items() -%}
+{{ emperor_block(v, k, operator, lb, delim, ind) }}
         {%- endfor %}
     {%- elif value is iterable -%}
-        {%- for v in value %}
-{{ emperor_block(v, key, operator, delim, ind) }}
+        {%- for v in value -%}
+{{ emperor_block(v, key, operator, lb, delim, ind) }}
         {%- endfor -%}
     {%- else -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- endif -%}
     {%- else -%}
     {%- endif -%}

--- a/uwsgi/emperor/files/emperor.jinja
+++ b/uwsgi/emperor/files/emperor.jinja
@@ -5,7 +5,6 @@
     {%- if value is number or value is string -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
-        {{ key|indent(ind, True) }}{{ operator }}
         {%- for k, v in value.items() %}
 {{ emperor_block(v, k, operator, delim, (ind + indent_increment)) }}
         {%- endfor %}

--- a/uwsgi/emperor/files/emperor.jinja
+++ b/uwsgi/emperor/files/emperor.jinja
@@ -6,7 +6,7 @@
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
         {%- for k, v in value.items() %}
-{{ emperor_block(v, k, operator, delim, (ind + indent_increment)) }}
+{{ emperor_block(v, k, operator, delim, ind) }}
         {%- endfor %}
     {%- elif value is iterable -%}
         {%- for v in value %}

--- a/uwsgi/emperor/files/vassal.jinja
+++ b/uwsgi/emperor/files/vassal.jinja
@@ -1,19 +1,19 @@
 {% set indent_increment = 4 %}
 
-{%- macro vassal_block(value, key=None, operator=' = ', delim='', ind=0) -%}
+{%- macro vassal_block(value, key=None, operator=' = ', lb='\n', delim='', ind=0) -%}
     {%- if value != None -%}
     {%- if value is number or value is string -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- elif value is mapping -%}
-        {%- for k, v in value.items() %}
+        {%- for k, v in value.items() -%}
 {{ vassal_block(v, k, operator, delim, ind) }}
         {%- endfor %}
     {%- elif value is iterable -%}
-        {%- for v in value %}
+        {%- for v in value -%}
 {{ vassal_block(v, key, operator, delim, ind) }}
         {%- endfor -%}
     {%- else -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- endif -%}
     {%- else -%}
     {%- endif -%}

--- a/uwsgi/emperor/files/vassal.jinja
+++ b/uwsgi/emperor/files/vassal.jinja
@@ -6,7 +6,7 @@
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
         {%- for k, v in value.items() %}
-{{ vassal_block(v, k, operator, delim, (ind + indent_increment)) }}
+{{ vassal_block(v, k, operator, delim, ind) }}
         {%- endfor %}
     {%- elif value is iterable -%}
         {%- for v in value %}

--- a/uwsgi/emperor/files/vassal.jinja
+++ b/uwsgi/emperor/files/vassal.jinja
@@ -5,7 +5,6 @@
     {%- if value is number or value is string -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
-        {{ key|indent(ind, True) }}{{ operator }}
         {%- for k, v in value.items() %}
 {{ vassal_block(v, k, operator, delim, (ind + indent_increment)) }}
         {%- endfor %}

--- a/uwsgi/emperor/files/vassal.jinja
+++ b/uwsgi/emperor/files/vassal.jinja
@@ -26,6 +26,4 @@
 #
 # This file is managed by Salt.
 [uwsgi]
-{% for key, value in config.items() %}
-{{ vassal_block(value, key) }}
-{%- endfor -%}
+{{ vassal_block(config) }}

--- a/uwsgi/files/application.jinja
+++ b/uwsgi/files/application.jinja
@@ -5,11 +5,10 @@
     {%- if value is number or value is string -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ '{' }}
+        {{ key|indent(ind, True) }}{{ operator }}
         {%- for k, v in value.items() %}
 {{ application_block(v, k, operator, delim, (ind + indent_increment)) }}
         {%- endfor %}
-{{ '}'|indent(ind, True) }}
     {%- elif value is iterable -%}
         {%- for v in value %}
 {{ application_block(v, key, operator, delim, ind) }}

--- a/uwsgi/files/application.jinja
+++ b/uwsgi/files/application.jinja
@@ -5,7 +5,6 @@
     {%- if value is number or value is string -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
-        {{ key|indent(ind, True) }}{{ operator }}
         {%- for k, v in value.items() %}
 {{ application_block(v, k, operator, delim, (ind + indent_increment)) }}
         {%- endfor %}

--- a/uwsgi/files/application.jinja
+++ b/uwsgi/files/application.jinja
@@ -6,7 +6,7 @@
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
         {%- for k, v in value.items() %}
-{{ application_block(v, k, operator, delim, (ind + indent_increment)) }}
+{{ application_block(v, k, operator, delim, ind) }}
         {%- endfor %}
     {%- elif value is iterable -%}
         {%- for v in value %}

--- a/uwsgi/files/application.jinja
+++ b/uwsgi/files/application.jinja
@@ -1,19 +1,19 @@
 {% set indent_increment = 4 %}
 
-{%- macro application_block(value, key=None, operator=' = ', delim='', ind=0) -%}
+{%- macro application_block(value, key=None, operator=' = ', lb='\n', delim='', ind=0) -%}
     {%- if value != None -%}
     {%- if value is number or value is string -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- elif value is mapping -%}
-        {%- for k, v in value.items() %}
-{{ application_block(v, k, operator, delim, ind) }}
-        {%- endfor %}
+        {%- for k, v in value.items() -%}
+{{ application_block(v, k, operator, lb, delim, ind) }}
+        {%- endfor -%}
     {%- elif value is iterable -%}
-        {%- for v in value %}
-{{ application_block(v, key, operator, delim, ind) }}
+        {%- for v in value -%}
+{{ application_block(v, key, operator, lb, delim, ind) }}
         {%- endfor -%}
     {%- else -%}
-        {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
     {%- endif -%}
     {%- else -%}
     {%- endif -%}

--- a/uwsgi/files/application.jinja
+++ b/uwsgi/files/application.jinja
@@ -26,6 +26,4 @@
 #
 # This file is managed by Salt.
 [uwsgi]
-{% for key, value in config.items() %}
-{{ application_block(value, key) }}
-{%- endfor -%}
+{{ application_block(config) }}


### PR DESCRIPTION
Dictionary only support for config blocks does not allow for the `env` setting, or other settings, to be repeated. This is required, for example, if multiple environmental variables is necessary. Also for many configuration options ordering is important, and lists will allow for ordering to be preserved.

For example, this config would now be possible:

``` yaml
applications:
    managed:
        config:
          - master: True
            uid: 'www-data'
            gid: 'www-data'
            plugins: 'logfile,python3'
            module: myproject.wsgi:application
            chdir: '/var/www/public'
            venv: '/usr/share/python/myproject/'
            log-master: True
            log-reopen: True
          - env: 'SECRET_KEY=secret-key'
          - env: DATABASE_NAME=project
          - env: DATABASE_HOST=db.example.com
          - env: DATABASE_USER=project_user
          - env: 'DATABASE_PASSWORD=secret-password'
```
